### PR TITLE
docs: update devcontainer feature references to use the correct GitHu…

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -131,6 +131,36 @@ uv run ruff format .
 
 ---
 
+## Releases and Publishing
+
+### Container Images
+
+The `containers.yml` workflow publishes Docker images and devcontainer features when:
+- A **release** is created (triggered by release events)
+- **Manual dispatch** from the Actions tab
+
+### Devcontainer Feature Publishing
+
+The devcontainer feature (`features/teambot/`) is published as an OCI artifact to GitHub Container Registry.
+
+**Workflow**: `.github/workflows/containers.yml` (job: `devcontainer-feature`)
+
+**What happens**:
+1. The `devcontainers/action@v1` action reads `features/teambot/devcontainer-feature.json`
+2. Packages the feature with `install.sh` as an OCI artifact
+3. Pushes to `ghcr.io/glav/features/teambot:1`
+
+**Version tags**:
+- The `:1` tag is derived from the major version in `devcontainer-feature.json` (`"version": "1.0.0"` → `:1`)
+- Users referencing `:1` automatically get the latest `1.x.x` release
+
+**To publish**:
+1. Update version in `features/teambot/devcontainer-feature.json` if needed
+2. Create a GitHub release
+3. The workflow runs automatically and pushes to GHCR
+
+---
+
 ## Next Steps
 
 - [Getting Started](getting-started.md) - Using TeamBot

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -69,7 +69,7 @@ Add to your `devcontainer.json`:
 ```json
 {
     "features": {
-        "ghcr.io/teambot-ai/features/teambot:1": {}
+        "ghcr.io/glav/features/teambot:1": {}
     }
 }
 ```
@@ -79,7 +79,7 @@ Add to your `devcontainer.json`:
 ```json
 {
     "features": {
-        "ghcr.io/teambot-ai/features/teambot:1": {
+        "ghcr.io/glav/features/teambot:1": {
             "version": "0.1.0"
         }
     }
@@ -92,10 +92,25 @@ Add to your `devcontainer.json`:
 {
     "features": {
         "ghcr.io/devcontainers/features/copilot-cli:latest": {},
-        "ghcr.io/teambot-ai/features/teambot:1": {}
+        "ghcr.io/glav/features/teambot:1": {}
     }
 }
 ```
+
+#### Understanding the Feature Reference
+
+The devcontainer feature reference follows this format:
+
+| Part | Meaning |
+|------|---------|
+| `ghcr.io` | GitHub Container Registry |
+| `/glav` | GitHub organization (repository owner) |
+| `/features/teambot` | Feature name (from `id` in feature definition) |
+| `:1` | Major version selector (from semver `1.x.x`) |
+
+The feature is published as an OCI artifact to GitHub Container Registry when TeamBot creates a new release. The `:1` selector automatically resolves to the latest `1.x.x` version.
+
+> **Note**: The devcontainer feature is only available after TeamBot publishes a release. If the reference doesn't resolve, check the [TeamBot releases page](https://github.com/glav/teambot/releases) to verify a release exists.
 
 ---
 

--- a/features/teambot/README.md
+++ b/features/teambot/README.md
@@ -9,7 +9,7 @@ Add to your `devcontainer.json`:
 ```json
 {
     "features": {
-        "ghcr.io/teambot-ai/features/teambot:1": {}
+        "ghcr.io/glav/features/teambot:1": {}
     }
 }
 ```
@@ -25,7 +25,7 @@ Add to your `devcontainer.json`:
 ```json
 {
     "features": {
-        "ghcr.io/teambot-ai/features/teambot:1": {
+        "ghcr.io/glav/features/teambot:1": {
             "version": "0.2.0"
         }
     }


### PR DESCRIPTION
This pull request updates documentation to clarify and correct the publishing and usage of the TeamBot devcontainer feature. The main focus is on updating the feature reference to use the correct GitHub Container Registry path and adding detailed instructions on how releases and publishing work.

**Documentation updates for devcontainer feature usage and publishing:**

*Updated feature reference across documentation:*
- Changed all references from `ghcr.io/teambot-ai/features/teambot:1` to `ghcr.io/glav/features/teambot:1` in `docs/guides/installation.md` and `features/teambot/README.md` to match the actual publishing location. [[1]](diffhunk://#diff-6f9f26600b378fac3fa34f820011f8dff2efc90aceebc4a4842024b2824497c3L72-R72) [[2]](diffhunk://#diff-6f9f26600b378fac3fa34f820011f8dff2efc90aceebc4a4842024b2824497c3L82-R82) [[3]](diffhunk://#diff-6f9f26600b378fac3fa34f820011f8dff2efc90aceebc4a4842024b2824497c3L95-R114) [[4]](diffhunk://#diff-07df175db63a3c62aa7d12498d72c7fafa04a6cf09f6837170e3c9228a87b84aL12-R12) [[5]](diffhunk://#diff-07df175db63a3c62aa7d12498d72c7fafa04a6cf09f6837170e3c9228a87b84aL28-R28)

*Added and improved publishing and usage documentation:*
- Added a new section in `docs/guides/development.md` explaining how container images and devcontainer features are published, including workflow details, version tagging, and publishing steps.
- Added a subsection to `docs/guides/installation.md` explaining the structure of the devcontainer feature reference, how versioning works, and a note about release availability.…b organization